### PR TITLE
fix: the watcher incorrectly parsed massif numbers

### DIFF
--- a/massifs/pathparse.go
+++ b/massifs/pathparse.go
@@ -71,7 +71,7 @@ func ParseMassifPathNumberExt(path string) (uint32, string, error) {
 	if parts[1] != V1MMRMassifExt && parts[1] != V1MMRSealSignedRootExt {
 		return 0, "", fmt.Errorf("%w: extension invalid %s", ErrMassifPathFmt, path)
 	}
-	number, err := strconv.ParseUint(parts[0], 16, 32)
+	number, err := strconv.ParseUint(parts[0], 10, 32)
 	if err != nil {
 		return 0, "", fmt.Errorf("%w: log file number invalid %s (%v)", ErrMassifPathFmt, path, err)
 	}

--- a/massifs/pathparse_test.go
+++ b/massifs/pathparse_test.go
@@ -58,7 +58,13 @@ func TestParseMassifPathNumberExt(t *testing.T) {
 		want1   string
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+		{
+			"decimal / hex confusion",
+			args{"v1/mmrs/tenant/84e0e9e9-d479-4d4e-9e8c-afc19a8fc185/0/massifs/0000000000000051.log"},
+			51,
+			"log",
+			false,
+		},
 		{
 			"happy case",
 			args{"v1/mmrs/tenant/84e0e9e9-d479-4d4e-9e8c-afc19a8fc185/0/massifs/0000000000000002.log"},


### PR DESCRIPTION
It parsed them from the blob path as hex. They are simple decimal counters.

AB#9541