### PR TITLE
fix: watcher missconfiguration checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .local
 **/test_results
+.vscode

--- a/massifs/watcher/watcher.go
+++ b/massifs/watcher/watcher.go
@@ -62,8 +62,7 @@ func (w Watcher) ConfigString() string {
 }
 
 func ConfigDefaults(cfg *WatchConfig) error {
-	zeroTime := time.Time{}
-	if cfg.Since.UnixMilli() == zeroTime.UnixMilli() && cfg.IDSince == "" && cfg.Horizon == 0 {
+	if cfg.Since.Equal(time.Time{}) && cfg.IDSince == "" && cfg.Horizon == 0 {
 		return fmt.Errorf("provide horizon on its own or either of the since parameters.")
 	}
 	// If horizon is provided, the since values are derived

--- a/massifs/watcher/watcher_test.go
+++ b/massifs/watcher/watcher_test.go
@@ -1,0 +1,77 @@
+package watcher
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type checkWatchConfig func(t *testing.T, cfg WatchConfig)
+
+func TestConfigDefaults(t *testing.T) {
+	hourSince := time.Now().Add(-time.Hour)
+
+	type args struct {
+		cfg *WatchConfig
+	}
+	tests := []struct {
+		name      string
+		args      args
+		errPrefix string
+		check     checkWatchConfig
+	}{
+		{
+			name: "horizon or since options are required",
+			args: args{
+				cfg: &WatchConfig{},
+			},
+			errPrefix: "provide horizon on its own or either of the since",
+		},
+
+		{
+			name: "poll with since an hour in the past",
+			args: args{
+				cfg: &WatchConfig{
+					Since: hourSince,
+				},
+			},
+			check: func(t *testing.T, cfg WatchConfig) {
+				assert.Equal(t, hourSince, cfg.Since)
+				assert.Equal(t, time.Second, cfg.Interval)
+				assert.NotEqual(t, "", cfg.IDSince) // should be set to IDTimeHex
+			},
+		},
+
+		{
+			name: "bad hex string for idtimestamp errors",
+			args: args{
+				cfg: &WatchConfig{
+					IDSince: "thisisnothex",
+				},
+			},
+			errPrefix: "encoding/hex: invalid byte",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ConfigDefaults(tt.args.cfg)
+			if err != nil {
+				if tt.errPrefix == "" {
+					t.Errorf("NewWatchConfig() unexpected error = %v", err)
+				}
+				if !strings.HasPrefix(err.Error(), tt.errPrefix) {
+					t.Errorf("NewWatchConfig() unexpected error = %v, expected prefix: %s", err, tt.errPrefix)
+				}
+			} else {
+				if tt.errPrefix != "" {
+					t.Errorf("NewWatchConfig() expected error prefix = %s", tt.errPrefix)
+				}
+			}
+			if tt.check != nil {
+				tt.check(t, *tt.args.cfg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes some of the checks for initialising the WatchConfig and adds test coverage.

AB#9753