### PR TITLE
feat: accept checkpoint v2 for verifiers

### DIFF
--- a/massifs/massifcontextverified.go
+++ b/massifs/massifcontextverified.go
@@ -169,20 +169,28 @@ func (mc *MassifContext) verifyContext(
 		return nil, err
 	}
 
-	if state.Version == int(MMRStateVersion1) {
-		return mc.verifyContextV1(msg, state, options)
+	switch state.Version {
+	case int(MMRStateVersion1):
+		fallthrough
+	case int(MMRStateVersion2):
+		return mc.verifyContextV1V2(msg, state, options)
+	case int(MMRStateVersion0):
+		return mc.verifyContextV0(msg, state, options)
 	}
-	return mc.verifyContextV0(msg, state, options)
+	return nil, fmt.Errorf("unsupported MMR state version %d", state.Version)
+
 }
 
-func (mc *MassifContext) verifyContextV1(
+func (mc *MassifContext) verifyContextV1V2(
 	msg *cose.CoseSign1Message, state MMRState, options ReaderOptions,
 ) (*VerifiedContext, error) {
 	var ok bool
 	var err error
 	var peaksB [][]byte
 
-	if state.Version != int(MMRStateVersion1) {
+	// There is no difference between v1 and v2 for the purposes of verification.
+	// We just need to accept both here.
+	if state.Version != int(MMRStateVersion1) && state.Version != int(MMRStateVersion2) {
 		return nil, fmt.Errorf("unsupported MMR state version %d", state.Version)
 	}
 


### PR DESCRIPTION
checkpoint v2 does not change the verification process.

v2 marks the presence of MMRIVER 02 format pre-signed receipts in the unprotected headers.