### PR TITLE
Ensure we check only for specific tenant log suffix

### DIFF
--- a/massifs/logdircache_test.go
+++ b/massifs/logdircache_test.go
@@ -267,3 +267,78 @@ func TestLogDirCacheEntry_setMassifStart(t *testing.T) {
 		})
 	}
 }
+
+// Test_checkLogPathAgainstCache tests:
+//
+// 1. absolute path vs relative path returns true
+// 2. absolute path vs absolute path returns true
+// 3. relative path vs relative path returns true
+// 4. different tenant logs returns false
+// 5. different logs within the same tenant return false
+func Test_checkLogPathAgainstCache(t *testing.T) {
+	type args struct {
+		cacheLogPath string
+		logPath      string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected bool
+	}{
+		{
+			name: "positive absolute vs relative",
+			args: args{
+				cacheLogPath: "/home/foo/merklelog/tenant/1234/0/massifs/0000.log",
+				logPath:      "local-merklelog/tenant/1234/0/massifs/0000.log",
+			},
+			expected: true,
+		},
+		{
+			name: "positive absolute vs relative reversed",
+			args: args{
+				cacheLogPath: "merklelog/tenant/1234/0/massifs/0000.log",
+				logPath:      "/usr/local/local-merklelog/tenant/1234/0/massifs/0000.log",
+			},
+			expected: true,
+		},
+		{
+			name: "positive absolute vs absolute",
+			args: args{
+				cacheLogPath: "/home/foo/local-merklelog/tenant/1234/0/massifs/0000.log",
+				logPath:      "/usr/local/local-merklelog/tenant/1234/0/massifs/0000.log",
+			},
+			expected: true,
+		},
+		{
+			name: "positive relative vs relative",
+			args: args{
+				cacheLogPath: "local-merklelog/tenant/1234/0/massifs/0000.log",
+				logPath:      "merklelog/tenant/1234/0/massifs/0000.log",
+			},
+			expected: true,
+		},
+		{
+			name: "different tenants",
+			args: args{
+				cacheLogPath: "local-merklelog/tenant/5678/0/massifs/0000.log",
+				logPath:      "merklelog/tenant/1234/0/massifs/0000.log",
+			},
+			expected: false,
+		},
+		{
+			name: "different logs",
+			args: args{
+				cacheLogPath: "local-merklelog/tenant/1234/0/massifs/0000.log",
+				logPath:      "merklelog/tenant/1234/0/massifs/0001.log",
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := checkLogPathAgainstCache(test.args.cacheLogPath, test.args.logPath)
+
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Overview
* Ensure we compare ONLY the suffix of the path when we replicate logs to ensure the cached path and given path tenants match correctly.

## Testing

* Added unit tests


Manually tested an updated veracity:

```
./veracity --tenant tenant/97e90a09-8c56-40df-a4de-42fde462ef6f replicate --latest --replicadir merklelogs --progress
tenants:   --- [--------------------------------------------------------------------]

(created another event here)

 ./veracity --tenant tenant/97e90a09-8c56-40df-a4de-42fde462ef6f replicate --latest --replicadir merklelogs --progress
tenants:   --- [--------------------------------------------------------------------]
```

RE: AB#10433