### PR TITLE
fix: range check bug when the log is tampered

### DIFF
--- a/massifs/massifcontextverified.go
+++ b/massifs/massifcontextverified.go
@@ -169,6 +169,10 @@ func (mc *MassifContext) verifyContext(
 		return nil, err
 	}
 
+	if state.MMRSize > mc.RangeCount() {
+		return nil, fmt.Errorf("%w: MMR size %d < %d", ErrStateSizeExceedsData, mc.RangeCount(), state.MMRSize)
+	}
+
 	switch state.Version {
 	case int(MMRStateVersion1):
 		fallthrough

--- a/massifs/massifcontextverifiedv0.go
+++ b/massifs/massifcontextverifiedv0.go
@@ -22,6 +22,10 @@ func (mc *MassifContext) verifyContextV0(
 		return nil, fmt.Errorf("unsupported MMR state version %d", state.Version)
 	}
 
+	if state.MMRSize > mc.RangeCount() {
+		return nil, fmt.Errorf("%w: MMR size %d < %d", ErrStateSizeExceedsData, mc.RangeCount(), state.MMRSize)
+	}
+
 	state.LegacySealRoot, err = mmr.GetRoot(state.MMRSize, mc, sha256.New())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When the local log is replaced with a foreign massive that is smaller than the legit seal we panic

AB#10433

test evidence

A new systemtest case has been added to veractity to catch this case testReplicateErrorForLogShorterThanSeal

with this change the output is

```
testVeracityVersion
testVeracityWatchPublicFindsActivity
testVeracityWatchLatestFindsActivity
testVeracityReplicateLogsPublicTenantWatchPipe
testVeracityReplicateLogsPublicTenantWatchLatestFlag
testVerifySingleEvent
testVerifyListEvents
testVerifySingleEventWithLocalMassifCopy
testFindTrieEntrySingleEvent
testFindTrieEntrySingleEventWithLocalMassifCopy
testFindMMREntrySingleEvent
testFindMMREntrySingleEventWithLocalMassifCopy
testReplicateErrorForLogShorterThanSeal
testReplicateErrorForMixedTenants
testReplicateLocalErrorForTamperedPartialToFullMassif
testVerboseOutput
testHelpOutputNoArgs
testValidEventNotinMassif
Expected (hex):
00000000  65 72 72 6f 72 3a 20 74  68 65 20 65 6e 74 72 79  |error: the entry|
00000010  20 69 73 20 6e 6f 74 20  69 6e 20 74 68 65 20 6c  | is not in the l|
00000020  6f 67 2e 20 66 6f 72 20  74 65 6e 61 6e 74 20 74  |og. for tenant t|
00000030  65 6e 61 6e 74 2f 36 65  61 35 63 64 30 30 2d 63  |enant/6ea5cd00-c|
00000040  37 31 31 2d 33 36 34 39  2d 36 39 31 34 2d 37 62  |711-3649-6914-7b|
00000050  31 32 35 39 32 38 62 62  62 34 0a                 |125928bbb4.|
0000005b
Actual (hex):
00000000  65 72 72 6f 72 3a 20 74  68 65 20 65 6e 74 72 79  |error: the entry|
00000010  20 69 73 20 6e 6f 74 20  69 6e 20 74 68 65 20 6c  | is not in the l|
00000020  6f 67 2e 20 66 6f 72 20  74 65 6e 61 6e 74 20 74  |og. for tenant t|
00000030  65 6e 61 6e 74 2f 36 65  61 35 63 64 30 30 2d 63  |enant/6ea5cd00-c|
00000040  37 31 31 2d 33 36 34 39  2d 36 39 31 34 2d 37 62  |711-3649-6914-7b|
00000050  31 32 35 39 32 38 62 62  62 34 0a                 |125928bbb4.|
0000005b
testNon200Response
testMissingMassifFile
testNotBlobFile
testInvalidBlobUrl
Expected (hex):
00000000  65 72 72 6f 72 3a 20 6e  6f 20 6a 73 6f 6e 20 67  |error: no json g|
00000010  69 76 65 6e 0a                                    |iven.|
00000015
Actual (hex):
00000000  65 72 72 6f 72 3a 20 6e  6f 20 6a 73 6f 6e 20 67  |error: no json g|
00000010  69 76 65 6e 0a                                    |iven.|
00000015

Ran 22 tests.

OK
```

without this change, the test results in

```
panic: runtime error: slice bounds out of range [:524256] with capacity 65248

goroutine 7 [running]:
github.com/datatrails/go-datatrails-merklelog/massifs.IndexedLogValue(...)
    github.com/datatrails/go-datatrails-merklelog/massifs@v0.3.3-0.20250219172850-d460ee5c0ee3/logformat.go:50
github.com/datatrails/go-datatrails-merklelog/massifs.(*MassifContext).get(0x14000051208?, 0x100a1f99c?)
    github.com/datatrails/go-datatrails-merklelog/massifs@v0.3.3-0.20250219172850-d460ee5c0ee3/
<snip>
ASSERT:1: a tampered log should exit 1 expected:<1> but was:<2>
ASSERT:not found:<error: There is insufficient data in the massif context to generate a consistency proof against the provided state>
shunit2:ERROR testReplicateErrorForLogShorterThanSeal() returned non-zero return code.
```