### PR TITLE
fix: 10433 remove the path checking

### DIFF
--- a/massifs/logdircache.go
+++ b/massifs/logdircache.go
@@ -627,13 +627,9 @@ func (d *LogDirCacheEntry) setSeal(
 	massifIndex uint32, sealFilename string, seal *SealedState,
 ) error {
 
-	// if we already have a log with the same massifIndex, read from a
-	// *different file*, we error out as the files in directories are
-	// potentially not for the same tenancy - which means the data is not
-	// correct
-	if cachedSealFile, ok := d.SealPaths[uint64(massifIndex)]; ok && cachedSealFile != sealFilename {
-		return fmt.Errorf("%w: %s and %s", ErrLogFileDuplicateMassifIndices, cachedSealFile, sealFilename)
-	}
+	// Note: If we have a mix of tenant massifs in the same directory we leave
+	// it to log consistency checks to prevent extending or overriting local
+	// files in appropriately.
 
 	// associate filename with the massif index
 	d.SealPaths[uint64(massifIndex)] = sealFilename

--- a/massifs/logdircache.go
+++ b/massifs/logdircache.go
@@ -602,13 +602,9 @@ func (d *LogDirCacheEntry) setMassifStart(opts DirCacheOptions, logfile string, 
 		return fmt.Errorf("%w: header=%d, expected=%d", ErrLogFileMassifHeightHeader, ms.MassifHeight, opts.massifHeight)
 	}
 
-	// if we already have a log with the same massifIndex, read from a
-	// *different file*, we error out as the files in directories are
-	// potentially not for the same tenancy - which means the data is not
-	// correct
-	if cachedLogFile, ok := d.MassifPaths[uint64(ms.MassifIndex)]; ok && cachedLogFile != logfile {
-		return fmt.Errorf("%w: %s and %s", ErrLogFileDuplicateMassifIndices, cachedLogFile, logfile)
-	}
+	// Note: If we have a mix of tenant massifs in the same directory we leave
+	// it to log consistency checks to prevent extending or overriting local
+	// files in appropriately.
 
 	// associate filename with the massif index
 	d.MassifPaths[uint64(ms.MassifIndex)] = logfile

--- a/tests/massifs/logdircache_test.go
+++ b/tests/massifs/logdircache_test.go
@@ -129,15 +129,6 @@ func TestNewLogDirCacheEntry(t *testing.T) {
 			outcome:   map[uint64]string{0: "/log/massif/0.log"},
 		},
 		{
-			name:      "fail two logs same index",
-			opts:      []massifs.DirCacheOption{massifs.WithReaderOption(massifs.WithMassifHeight(14))},
-			opener:    op,
-			dirlister: dl,
-			logs:      "/same/log",
-			isdir:     true,
-			wantErr:   massifs.ErrLogFileDuplicateMassifIndices,
-		},
-		{
 			name:      "valid + invalid height not default",
 			opts:      []massifs.DirCacheOption{massifs.WithReaderOption(massifs.WithMassifHeight(14))},
 			opener:    op,


### PR DESCRIPTION
The path checking was intended as an early guard against the case where a mix of tenant massifs in the same directory would cause replication to fail. The intent was to help the caller by providing them and indication of the problematic file names

Instead, we now have tests (in veracity) which show the explicit errors for this case are surfaced from this library and are acted on appropriately.