### PR TITLE
fix: ReadMassifStart returns inconsistent errors when the file is not a massif

### DIFF
--- a/tests/massifs/logdircache_test.go
+++ b/tests/massifs/logdircache_test.go
@@ -143,7 +143,6 @@ func TestNewLogDirCacheEntry(t *testing.T) {
 			opts:      []massifs.DirCacheOption{massifs.WithReaderOption(massifs.WithMassifHeight(14))},
 			opener:    op,
 			dirlister: dl,
-			wantErr:   massifs.ErrLogFileBadHeader,
 			logs:      "/logs/short",
 			isdir:     true,
 			outcome:   map[uint64]string{0: "/logs/short/0.log"},


### PR DESCRIPTION
The post release manual test is easy to get wrong because of this bug: a file smaller than 32 bytes was correctly determined to be "not a massif", but the specific error was treated as unknownn and terminal

This change ensures a consistent error is returned to indicate "invalid massif header"

Note: as the regresion for this would apear in veracity, that is where the test has been added

Background:

veractity always operates on a "log". When --data-local is in effect, this means that it scans the  replica dir for valid massif files building up a map of available massifs for the subsequent command acctions.

Because we are not in control over what clients put in their replica directories, or how they chose to manage their files, we detect "is valid massif file" by reading the first 32 bytes of each candidate file and checking for the file identification markers.

The logic for "not a massif file", assumed only a single error could be returned for "baddly formated massif header"

This change makes that assumption valid.